### PR TITLE
neaten up/tabsCheckout

### DIFF
--- a/client/src/components/commonComponents/Footer/Copyrights.jsx
+++ b/client/src/components/commonComponents/Footer/Copyrights.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link, Typography } from '@material-ui/core/';
+
+const Copyright = () => (
+  <Typography variant="body2" color="textSecondary" align="center">
+    <Link color="inherit" href="https://www.urbannatural.com/">
+      Urban natural
+    </Link>{' '}
+    {new Date().getFullYear()}
+    {'.'}
+  </Typography>
+);
+
+export default Copyright;

--- a/client/src/components/commonComponents/Footer/index.js
+++ b/client/src/components/commonComponents/Footer/index.js
@@ -1,0 +1,3 @@
+import Footer from './Copyrights';
+
+export default Footer;

--- a/client/src/components/commonComponents/TabsCheckout/index.js
+++ b/client/src/components/commonComponents/TabsCheckout/index.js
@@ -1,27 +1,15 @@
 import React, { useState, Fragment } from 'react';
 import {
-  CssBaseline,
-  AppBar,
-  Toolbar,
   Paper,
   Stepper,
   Step,
   StepLabel,
   Button,
   Typography,
-  Link,
 } from '@material-ui/core';
 import useStyles from './style';
-
-const Copyright = () => (
-  <Typography variant="body2" color="textSecondary" align="center">
-    <Link color="inherit" href="https://www.urbannatural.com/">
-      Urban natural
-    </Link>{' '}
-    {new Date().getFullYear()}
-    {'.'}
-  </Typography>
-);
+import Confirmation from '../../layouts/ConfirmationTab';
+import Copyright from '../Footer';
 
 const tabs = ['Contact Info', 'Questions', 'Book'];
 
@@ -50,15 +38,6 @@ const TabsCheckout = () => {
   };
   return (
     <Fragment>
-      <CssBaseline />
-      <AppBar position="absolute" color="default" className={classes.appBar}>
-        <Toolbar>
-          <Typography variant="h6" color="inherit" noWrap>
-            Urban Natural
-          </Typography>
-        </Toolbar>
-      </AppBar>
-
       <main className={classes.layout}>
         <Paper className={classes.paper}>
           <Typography component="h1" variant="h4" align="center">
@@ -73,24 +52,7 @@ const TabsCheckout = () => {
           </Stepper>
           <Fragment>
             {activeTab === tabs.length ? (
-              <Fragment>
-                <Typography variant="h6" gutterBottom>
-                  Thank you!
-                </Typography>
-                <Typography variant="h6" gutterBottom>
-                  Our health and saftey rules
-                </Typography>
-                <Typography variant="subtitle1">
-                  1. All visitors must wear face masks before entering the
-                  building.
-                  <br />
-                  2. No more than 3 People allowed to be in the showroom at
-                  once.
-                  <br />
-                  3. Make sure to follow the American Red Cross Instuctions of
-                  Saftey.
-                </Typography>
-              </Fragment>
+              <Confirmation />
             ) : (
               <Fragment>
                 {getTabContent(activeTab)}

--- a/client/src/components/layouts/ConfirmationTab/confirmationTab.jsx
+++ b/client/src/components/layouts/ConfirmationTab/confirmationTab.jsx
@@ -7,14 +7,14 @@ const Confirmation = () => (
       Thank you!
     </Typography>
     <Typography variant="h6" gutterBottom>
-      Our health and saftey rules
+      Our health and safety rules
     </Typography>
     <Typography variant="subtitle1">
       1. All visitors must wear face masks before entering the building.
       <br />
       2. No more than 3 People allowed to be in the showroom at once.
       <br />
-      3. Make sure to follow the American Red Cross Instuctions of Saftey.
+      3. Make sure to follow the American Red Cross Instuctions of Safety.
     </Typography>
   </Fragment>
 );

--- a/client/src/components/layouts/ConfirmationTab/confirmationTab.jsx
+++ b/client/src/components/layouts/ConfirmationTab/confirmationTab.jsx
@@ -1,0 +1,22 @@
+import React, { Fragment } from 'react';
+import { Typography } from '@material-ui/core';
+
+const Confirmation = () => (
+  <Fragment>
+    <Typography variant="h6" gutterBottom>
+      Thank you!
+    </Typography>
+    <Typography variant="h6" gutterBottom>
+      Our health and saftey rules
+    </Typography>
+    <Typography variant="subtitle1">
+      1. All visitors must wear face masks before entering the building.
+      <br />
+      2. No more than 3 People allowed to be in the showroom at once.
+      <br />
+      3. Make sure to follow the American Red Cross Instuctions of Saftey.
+    </Typography>
+  </Fragment>
+);
+
+export default Confirmation;

--- a/client/src/components/layouts/ConfirmationTab/index.js
+++ b/client/src/components/layouts/ConfirmationTab/index.js
@@ -1,0 +1,3 @@
+import Confirmation from './confirmationTab';
+
+export default Confirmation;


### PR DESCRIPTION
### modification 

- [x] make copyright function as a footer
- [x] split the confirmation tab from the TabCheckout shared component 
I've initiated each folder with a **xxx.jsx** file named with the component functionality and another **index.js** file
please let me know if we can change our file structure into this type or just staying at the one that we're using currently

### Testing
1. write these following commands down on your terminal :
```
$ pull origin neatingUp/tabsCheckout
$ npm run client
```
2. browse http://localhost:3000/reservation.