### PR TITLE
Component/guideline/style

### DIFF
--- a/client/src/components/commonComponents/TabsCheckout/style.js
+++ b/client/src/components/commonComponents/TabsCheckout/style.js
@@ -5,8 +5,8 @@ const useStyles = makeStyles((theme) => ({
     width: 'auto',
     marginLeft: theme.spacing(2),
     marginRight: theme.spacing(2),
-    [theme.breakpoints.up(600 + theme.spacing(2) * 2)]: {
-      width: 700,
+    [theme.breakpoints.up(800 + theme.spacing(2) * 2)]: {
+      width: 800,
       marginLeft: 'auto',
       marginRight: 'auto',
     },

--- a/client/src/components/layouts/Guideline/Guideline.jsx
+++ b/client/src/components/layouts/Guideline/Guideline.jsx
@@ -7,13 +7,13 @@ import {
   Typography,
   Button,
   Paper,
-  Grid,
+  Box,
 } from '@material-ui/core';
 import useStyles from './style';
 
 const getSteps = () => [
   'Basic contact info',
-  'Questionnaire',
+  'Before visit questions',
   'Pick date and time',
 ];
 const Guideline = () => {
@@ -23,20 +23,17 @@ const Guideline = () => {
   return (
     <main className={classes.layout}>
       <Paper elevation={10} className={classes.paper}>
-        <div className={classes.root}>
-          <Grid item xs={12}>
+        <Box className={classes.root}>
+          <Box className={classes.titles}>
             <Typography className={classes.header}>
               We’ll take you through our 3-step booking process
             </Typography>
-          </Grid>
-          <Grid item xs={12}>
             <Typography className={classes.description}>
               To prevent the spread of COVID-19 and reduce the potential risk of
               exposure to our staff and visitors. we will take through this very
               quick process.
             </Typography>
-          </Grid>
-
+          </Box>
           <Stepper activeStep={-1} orientation="vertical">
             {steps.map((label) => (
               <Step key={label}>
@@ -51,12 +48,12 @@ const Guideline = () => {
               </Step>
             ))}
           </Stepper>
-          <Button variant="contained" className={classes.button}>
-            <Link to="/reservation" className={classes.startLink}>
+          <Link to="/reservation" className={classes.startLink}>
+            <Button variant="contained" className={classes.button}>
               START
-            </Link>
-          </Button>
-        </div>
+            </Button>
+          </Link>
+        </Box>
       </Paper>
     </main>
   );

--- a/client/src/components/layouts/Guideline/style.js
+++ b/client/src/components/layouts/Guideline/style.js
@@ -12,8 +12,8 @@ const useStyles = makeStyles((theme) => ({
     width: 'auto',
     marginLeft: theme.spacing(2),
     marginRight: theme.spacing(2),
-    [theme.breakpoints.up(700 + theme.spacing(2) * 2)]: {
-      width: 700,
+    [theme.breakpoints.up(800)]: {
+      width: 800,
       marginLeft: 'auto',
       marginRight: 'auto',
     },
@@ -21,6 +21,8 @@ const useStyles = makeStyles((theme) => ({
   paper: {
     marginTop: theme.spacing(3),
     marginBottom: theme.spacing(3),
+    marginLeft: theme.spacing(1),
+    marginRight: theme.spacing(1),
     padding: theme.spacing(2),
     [theme.breakpoints.up(600 + theme.spacing(3) * 2)]: {
       marginTop: theme.spacing(6),
@@ -28,14 +30,27 @@ const useStyles = makeStyles((theme) => ({
       padding: theme.spacing(3),
     },
   },
+  titles: {
+    display: 'flex',
+    justifyContent: 'center',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
   header: {
     fontSize: '28px',
     color: '#333333',
     textAlign: 'center',
+    [theme.breakpoints.down(970)]: {
+      fontSize: '22px',
+    },
   },
   description: {
     fontSize: '15px',
     textAlign: 'center',
+    [theme.breakpoints.down(970)]: {
+      fontSize: '14px',
+      marginTop: 5,
+    },
   },
   label: {
     color: 'rgba(0,0,0,0.87)',


### PR DESCRIPTION
## Content
- Make the width of the paper bigger.
- Make the start link on the button. 
- Make the font size for the title in the mobile view smaller. 
- Replace the "Questionnaire" text to "Before visit questions". 

## UI 
### Desktop View
![Screenshot from 2020-07-23 16-47-04](https://user-images.githubusercontent.com/54964739/88294130-8ef1dc80-cd04-11ea-94b1-4a50301de636.png)
### Mobile View
![Screenshot from 2020-07-23 16-47-11](https://user-images.githubusercontent.com/54964739/88294137-90bba000-cd04-11ea-9007-ed6f3589ae6d.png)

## Testing
on terminal use the following commands:
- pull origin component/guideline/style
- npm run client
- go to http://localhost:3000/guideline on your browser.